### PR TITLE
power.status v2, OLED screens rework, and output PD current-limit tuning

### DIFF
--- a/common/protocol.h
+++ b/common/protocol.h
@@ -229,6 +229,50 @@ typedef struct WUPS_PACKED {
 #define WUPS_PWR_FAULT_OTP        (1u << 2)
 #define WUPS_PWR_FAULT_PD_NEG     (1u << 3)
 
+/* power.status v2 — emitted by CH32X every 1 s (EVENT) and on demand.
+ * Redesign of v1, NOT a prefix-compatible superset: receivers MUST dispatch
+ * on the version byte (offset 0) and pick the matching decoder. Improvements
+ * over v1: dedicated INPUT (HUSB238) and OUTPUT (CH32X source) PD contracts;
+ * VSYS / IIN are real fields instead of being aliased onto pd_contract_*;
+ * the two temperature sensors are split; booleans are packed into `flags`.
+ *
+ * Sentinels: pd_in / pd_out fields = 0 means "no contract / not connected";
+ * temp_mp_dC = -32768 means MP2762A unpowered (junction temp unavailable). */
+typedef struct WUPS_PACKED {
+    uint8_t  version;        /* = 2 */
+    uint8_t  flags;          /* see WUPS_PWR2_FLAG_* */
+    uint8_t  charge_state;   /* 0=idle 1=charging 2=charged 3=fault */
+    uint8_t  reserved;       /* 0 (alignment / future use) */
+    /* --- INPUT --- */
+    uint16_t vbus_in_mV;     /* PA1 ADC (post ideal-diode OR of USB-C + barrel) */
+    uint16_t pd_in_mV;       /* HUSB238 negotiated input contract; 0 = N/A */
+    uint16_t pd_in_mA;       /* HUSB238 negotiated input contract; 0 = N/A */
+    /* --- OUTPUT --- */
+    uint16_t vbus_out_mV;    /* PA0 ADC (independent measurement of the Pi rail) */
+    uint16_t vout_set_mV;    /* TPS55289 commanded voltage */
+    uint16_t vout_read_mV;   /* TPS55289 voltage readback */
+    uint16_t iout_limit_mA;  /* TPS55289 current LIMIT (NOT a load-current measurement) */
+    uint16_t pd_out_mV;      /* output PD contract to the Pi; 0 = rail off */
+    uint16_t pd_out_mA;      /* output PD contract to the Pi; 0 = rail off */
+    /* --- BATTERY --- */
+    uint16_t vbat_mV;        /* PA5 ADC (authoritative VBAT) */
+    int16_t  ichg_mA;        /* MP2762A charge current; 0 on discharge (not measured) */
+    /* --- SYSTEM --- */
+    uint16_t vsys_mV;        /* MP2762A VSYS rail (feeds TPS55289 VIN) */
+    uint16_t iin_mA;         /* MP2762A charger input current */
+    int16_t  temp_lm_dC;     /* LM75B board temp, deci-Celsius */
+    int16_t  temp_mp_dC;     /* MP2762A junction temp, deci-Celsius; -32768 = N/A */
+    uint16_t faults;         /* lo byte = MP2762A fault; bits 8/9/10 = TPS SCP/OCP/OVP */
+    uint32_t uptime_s;       /* CH32X uptime (restart detection) */
+} wups_power_status_v2_t;     /* 40 bytes */
+
+/* power.status v2 `flags` bits. */
+#define WUPS_PWR2_FLAG_DC_IN_EN     (1u << 0)  /* PA6 DC_INP_EN_SRC asserted */
+#define WUPS_PWR2_FLAG_VBUS_OUT_EN  (1u << 1)  /* PA7 VBUS_OUT_EN asserted   */
+#define WUPS_PWR2_FLAG_BATT_PRESENT (1u << 2)  /* MP2762A debounced presence */
+#define WUPS_PWR2_FLAG_POWER_GOOD   (1u << 3)  /* MP2762A ACOK (mains good)   */
+#define WUPS_PWR2_FLAG_USB_C_ATTACH (1u << 4)  /* HUSB238 PD contract present */
+
 /* power.cycle */
 typedef struct WUPS_PACKED {
     uint8_t  version;        /* = 1 */

--- a/common/protocol_desc.md
+++ b/common/protocol_desc.md
@@ -128,7 +128,7 @@ cycles possible).
 
 | Op   | Name           | Direction              | Payload struct              |
 |------|----------------|------------------------|------------------------------|
-| 0x01 | status         | EVENT (CH32X→RP2040 @1Hz), RESP on query | `wups_power_status_v1_t` |
+| 0x01 | status         | EVENT (CH32X→RP2040 @1Hz), RESP on query | `wups_power_status_v2_t` (was `_v1_t`) |
 | 0x02 | enable         | REQ                    | empty                        |
 | 0x03 | disable        | REQ                    | empty                        |
 | 0x04 | cycle          | REQ                    | `wups_power_cycle_v1_t`     |
@@ -138,6 +138,16 @@ cycles possible).
 CH32X emits `power.status` autonomously every 1 s, **unicast to RP2040**.
 RP2040 caches the latest sample and includes the data in its own
 `host.aggregate` frames sent to RPi.
+
+Since 2026-06: the payload is **`wups_power_status_v2_t` (version byte = 2,
+40 bytes)** — a redesign, not a v1 superset, so every receiver dispatches on
+the version byte (offset 0): `1` → `wups_power_status_v1_t` (legacy), `2` →
+`wups_power_status_v2_t`. v2 adds separate INPUT (HUSB238) and OUTPUT PD
+contracts, real `vsys_mV`/`iin_mA` (v1 aliased these onto `pd_contract_*`),
+split LM75B/MP2762A temperatures, and a packed `flags` byte. Roll-out order:
+make all readers version-tolerant (RPi host, RP2040) **before** the CH32X
+emitter flips to v2; the RP2040 hub must forward the raw payload length, not
+`sizeof(v1)`. ESP32 is a transparent forwarder (v2 ≤ 64 B, no change).
 
 ### Class 0x03 NET (ESP32)
 
@@ -200,7 +210,7 @@ Every 1 s CH32X emits unicast to RP2040:
 
 ```
 DST=02  SRC=03  CLASS=02  OP=01  FLAGS=04  SEQ=auto
-LEN=18 00  payload=wups_power_status_v1_t (24 B)
+LEN=28 00  payload=wups_power_status_v2_t (40 B)   # v1 was 20 B (LEN=14 00)
 ```
 
 RP2040 caches it. RP2040's own `host.status`-equivalent frame to RPi

--- a/docs/QuickStart.md
+++ b/docs/QuickStart.md
@@ -1,0 +1,157 @@
+# Web3 Pi UPS — Quick Start
+
+A compact DC UPS for the **Raspberry Pi 5**: powers the Pi over USB‑C, charges
+and switches to a battery seamlessly on power loss, and reports its status to
+the Pi over the **same cable** plus a small OLED + 2 buttons.
+
+---
+
+## ⚠️ Read this first
+
+- **This is a prototype.** Always operate it **under supervision**. Do not leave it unattended, especially under havy load.
+- **The battery MUST have a built‑in BMS / protection.** This board relies on
+  the battery pack's own protection (over‑charge, over‑discharge, over‑current,
+  short). All Sony NP‑F packs we know of have it — but **verify** before use,
+  especially for third‑party/clone packs. Never use a raw, unprotected cell.
+- **Li‑ion safety:** use the correct battery type, don't short the terminals,
+  don't charge a damaged/swollen pack.
+
+---
+
+## TL;DR — get running in 3 steps
+
+1. **Insert a battery** (Sony NP‑F, see below).
+2. **Connect input power** — a USB‑C PD charger **or** a DC barrel supply. The
+   OLED lights up and the battery starts charging.
+3. **Connect the Raspberry Pi 5** to the UPS **`OUT`** USB‑C port (one cable =
+   power **and** data) — the Pi boots.
+
+On input‑power loss the UPS keeps the Pi running from the battery automatically.
+
+---
+
+## Connections — where is what
+
+| Port | Function |
+|------|----------|
+| **`OUT`** (USB‑C) | **Output to the Raspberry Pi 5** — 5 V power **+ USB data** on one cable. |
+| **Input** (USB‑C PD) | External power in. Voltage is auto‑negotiated (see below). |
+| **Input** (DC barrel jack) | Alternative external power in, **12–20 V DC**. |
+
+> If both a USB‑C source and the barrel jack are connected, the higher voltage
+> is used (an ideal‑diode OR combines them).
+
+---
+
+## Batteries
+
+- Use **Sony NP‑F (L‑series)** packs: **NP‑F550 / NP‑F770 / NP‑F970** (2S
+  Li‑ion, 7.2 V nominal). Bigger number = more capacity / longer runtime.
+- **The pack MUST have an internal BMS.** All genuine NP‑F packs do; the board
+  has **no per‑cell protection of its own**, so the pack's BMS is the safety
+  layer. (The external protection circuit was intentionally removed because
+  NP‑F packs only expose `BAT+ / BAT−` and already protect themselves.)
+- **Hot‑swap:** while running on **external power**, you can swap the battery
+  without powering down the Pi.
+- Charging targets ~8.1 V (gentle full); charge current is modest by design.
+
+---
+
+## Power & USB‑C PD
+
+**Input (PD is automatic — no configuration):**
+- Plug in any USB‑C PD charger. The UPS reads **all PD profiles the charger
+  offers** and **auto‑selects the best one** (it prefers efficient mid
+  voltages, up to **20 V**). You don't set anything.
+- Or use a **12–20 V DC barrel** supply.
+
+**Output to the Pi (USB‑C PD source):**
+- The UPS is a **USB‑C PD source** and advertises **four output PD profiles**. The
+  Pi 5 (or any PD sink) picks one, and the on‑board buck‑boost converter is set to
+  that rail:
+
+  | Output PD profile | Notes |
+  |---|---|
+  | **5.1 V / 5 A** | **Default** — the Raspberry Pi 5's full power (needs an e‑marked cable for 5 A). |
+  | 9 V / 3 A | For other USB‑C PD sinks. |
+  | 12 V / 2.25 A | For other USB‑C PD sinks. |
+  | 15 V / 1.8 A | For other USB‑C PD sinks. |
+
+- A **Raspberry Pi 5 uses the 5.1 V / 5 A profile** (negotiated automatically); the
+  higher‑voltage profiles are there for general USB‑C PD devices.
+
+**How much input power do you need?**
+- To deliver the Pi's **full 5.1 V / 5 A (~25–27 W)** *and* charge the battery at
+  the same time, the input source should provide **at least ~36 W** — converter
+  losses, battery charging and overhead all add up. A **45 W or 65 W** USB‑C PD
+  charger gives comfortable headroom. A weaker source still works, but output
+  and/or charging will be reduced.
+
+**Cables — e‑marker for 5 A:**
+- Drawing **5 A** over USB‑C requires an **e‑marked cable** (it carries a chip
+  that authorises 5 A). The official Raspberry Pi 27 W supply uses 5 V/5 A and
+  ships with such a cable.
+
+---
+
+## OLED display & navigation
+
+A small **OLED** plus **two buttons (LEFT / RIGHT)** show live status.
+
+**Navigation:**
+- Short‑press a button on the **Home** screen to enter the screen cycle;
+  **RIGHT** = next, **LEFT** = previous.
+- After **20 s** of no button activity it returns to **Home**.
+- (Long‑press LEFT opens the system menu, when the optional LTE‑M module is
+  fitted.)
+
+**Screens:**
+
+| Screen | Shows |
+|--------|-------|
+| **Home** | Battery icon, **SOC %**, charge state, and Vbat / Vin / Vout. |
+| **INPUT** | `VIN` (input voltage), the negotiated **input PD** contract (V / A / W) or `N/A`, and the source type. |
+| **OUTPUT** | Output **voltage**, the **output PD** contract to the Pi (V / A), and the current **limit**. |
+| **BATTERY** | Battery **voltage + SOC %**, **Mode**, and charge current (`Ich`). |
+| **SYSTEM** | **Uptime**, the two board **temperatures**, and **fault** flags. |
+
+**Mode / charge‑state labels:**
+`DSC` = discharging (on battery) · `CHG` = charging · `FUL` = full ·
+`PRE` = pre‑charge · `IDL` = on mains, not charging.
+
+---
+
+## Raspberry Pi integration
+
+- The **`OUT`** USB‑C cable carries **both power and USB data** to the Pi 5 —
+  one cable, no extra wiring.
+- The UPS appears on the Pi as a **USB serial port** (identifies itself as
+  `Web3_Pi / Web3_Pi_UPS`), so the Pi can read status and send commands.
+- **Web3 Pi vOS has native support** — it talks to the UPS over that serial
+  port out of the box (telemetry, safe shutdown on low battery, etc.).
+
+---
+
+## Quick facts
+
+- 🔌 **Two inputs:** USB‑C PD (auto‑negotiated) **or** 12–20 V DC barrel.
+- 🔋 **Battery:** Sony NP‑F (2S Li‑ion); **must have its own BMS**; **hot‑swappable** on external power.
+- ⚡ **Output (USB‑C PD source):** four profiles — **5.1 V / 5 A** (default, Pi 5), 9 V / 3 A, 12 V / 2.25 A, 15 V / 1.8 A.
+- 🤖 **PD input is automatic:** it queries the charger and picks the best profile (≤ 20 V) — no setup.
+- 🧮 **Headroom:** budget **~36 W+** input for full output **plus** charging.
+- 🪢 **e‑marked cable** needed for 5 A.
+- 🖥️ **One cable to the Pi** = power + data; shows up as a **serial port**; **vOS native support**.
+- 📺 **OLED + 2 buttons:** Home + INPUT / OUTPUT / BATTERY / SYSTEM screens; auto‑returns to Home after 20 s.
+- ⚙️ **Seamless switchover:** keeps the Pi running on battery when input power is lost.
+- 🧪 **Prototype:** use under supervision, at your own risk.
+
+---
+
+## Notes & limitations
+
+- **Don't feed power into the `OUT` port.** The output is a power *source*;
+  connecting another charger to it is an unsupported, potentially damaging
+  configuration.
+- SOC (%) is derived from battery voltage; while charging it may read slightly
+  optimistically and settle once charging stops.
+- This document describes the current prototype firmware; details may change.

--- a/firmware-ch32x/User/PD_Process.c
+++ b/firmware-ch32x/User/PD_Process.c
@@ -790,15 +790,21 @@ void PD_Main_Proc( )
                      * asked for. ReqPDO_Idx is 1..4 per our SrcCap;
                      * any out-of-range value would have been rejected
                      * in the REQUEST handler before reaching here. */
+                    /* curr is the TPS55289 current limit, set a few % above the
+                     * negotiated PDO current so the rail can source full rated
+                     * power (≈27 W) under test load without the converter folding
+                     * into constant-current at the profile boundary. Limits sit
+                     * on the 0.1 A grid so the 2 s watchdog re-apply (from the
+                     * 0.1 A telemetry cache) reproduces them exactly. */
                     float volt = 5.0f;
                     float curr = 3.0f;
                     switch (PD_Ctl.ReqPDO_Idx)
                     {
-                        case 1: volt = 5.0f;  curr = 5.0f;  break;
-                        case 2: volt = 9.0f;  curr = 3.0f;  break;
-                        case 3: volt = 12.0f; curr = 2.25f; break;
-                        case 4: volt = 15.0f; curr = 1.8f;  break;
-                        default: /* keep safe defaults */     break;
+                        case 1: volt = 5.0f;  curr = 5.2f; break;  /* PDO 5V/5A     -> 5.2A (+4.0%) */
+                        case 2: volt = 9.0f;  curr = 3.1f; break;  /* PDO 9V/3A     -> 3.1A (+3.3%) */
+                        case 3: volt = 12.0f; curr = 2.3f; break;  /* PDO 12V/2.25A -> 2.3A (+2.2%) */
+                        case 4: volt = 15.0f; curr = 1.9f; break;  /* PDO 15V/1.8A  -> 1.9A (+5.6%) */
+                        default: /* keep safe defaults */    break;
                     }
                     tps55289_set_cdc_compensation(CDC_COMP_0V7);
                     tps55289_set_current_limit(curr);

--- a/firmware-ch32x/User/main.c
+++ b/firmware-ch32x/User/main.c
@@ -83,6 +83,7 @@ volatile u16    DC_Inp_ADC_Val = 0;
 static UINT16   DC_Inp_Voltage_mV = 0;
 volatile u16    Vbat_ADC_Val = 0;
 static UINT16   Vbat_Voltage_mV = 0;
+static UINT16   Vbus_Out_Voltage_mV = 0;   /* PA0 ADC, same 27.4k/5.1k divider as PA1 */
 static UINT16   Json_Timer_Ms = 0;
 static UINT16   Temp_Timer_Ms = 0;
 static UINT16   Chg_Timer_Ms = 0;
@@ -502,63 +503,80 @@ static void wups_send_frame(uint8_t dst, uint8_t cls, uint8_t op,
     Usart2_Send_Bytes(trailer, 4);
 }
 
-/* Compose power.status from current globals and send to `dst`.
+/* Negotiated OUTPUT PD contract (CH32X is the source to the Pi). Derived
+ * from the accepted PDO index PD_Ctl.ReqPDO_Idx (1..4); mirrors the advertised
+ * SrcCap_5V5A_Tab / the STA_TX_ACCEPT switch in PD_Process.c. 0 = rail off. */
+static void pd_out_contract(uint16_t *mv, uint16_t *ma)
+{
+    switch (PD_Ctl.ReqPDO_Idx) {
+    case 1: *mv = 5000;  *ma = 5000; break;
+    case 2: *mv = 9000;  *ma = 3000; break;
+    case 3: *mv = 12000; *ma = 2250; break;
+    case 4: *mv = 15000; *ma = 1800; break;
+    default: *mv = 0; *ma = 0; break;  /* no contract / rail off */
+    }
+}
+
+/* Compose power.status v2 from current globals and send to `dst`.
  * Used both for the 1 Hz periodic EVENT (dst=RP2040) and as RESP to
- * system.status_query (dst=requester). */
+ * system.status_query (dst=requester). See wups_power_status_v2_t. */
 static void wups_send_power_status(uint8_t dst, uint8_t flags, uint8_t seq)
 {
-    wups_power_status_v1_t s;
-    s.version        = 1;
-    s.charge_state   = (uint8_t)Chg_Data.chg_state;
-    /* vbus_in: always from our own PA1 ADC. Works in every state — mains
-     * present, mains absent, Q222 cut, MP2762A dead. The MP2762A's VIN
-     * reading is redundant when mains is on and unavailable on battery; we
-     * ignore it unconditionally to keep the source uniform. */
-    s.vbus_in_mV     = DC_Inp_Voltage_mV;
-    /* Tps_Vread_v10 / Tps_Iread_a10 are 0.1 V / 0.1 A units — *100 → mV / mA. */
-    s.vbus_out_mV    = (uint16_t)((int32_t)Tps_Vread_v10 * 100);
-    s.ibus_out_mA    = (int16_t)((int32_t)Tps_Iread_a10 * 100);
-    /* vbat: always from our own PA5 ADC. Available whether MP2762A is alive
-     * or not. With mains on and no battery present, BATTFET leakage can
-     * leave residual voltage on PPVAR_VBAT+ caps; that's a known edge case
-     * (the panel infers "no battery" from charge state + faults). */
-    s.vbat_mV        = Vbat_Voltage_mV;
-    s.ibat_mA        = (int16_t)Chg_Data.ichg_ma;
-    /* Hottest of LM75B (board, near TPS55289) and MP2762A junction.
-     * When MP2762A is unpowered, mp2762a_read_all() sets tjunc_c10 to
-     * MP2762A_TJ_NA — use LM75B alone in that case. Both inputs are in
-     * deci-Celsius. */
+    wups_power_status_v2_t s;
+    s.version      = 2;
+
+    /* Packed booleans. PA6/PA7 are read back from the output data register
+     * (idiom shared with mp2762a_powered()). */
+    s.flags = 0;
+    if (GPIO_ReadOutputDataBit(GPIOA, GPIO_Pin_6)) s.flags |= WUPS_PWR2_FLAG_DC_IN_EN;
+    if (GPIO_ReadOutputDataBit(GPIOA, GPIO_Pin_7)) s.flags |= WUPS_PWR2_FLAG_VBUS_OUT_EN;
+    if (mp2762a_is_battery_present())              s.flags |= WUPS_PWR2_FLAG_BATT_PRESENT;
+    if (Chg_Data.power_good)                       s.flags |= WUPS_PWR2_FLAG_POWER_GOOD;
+    if (Husb_Data.attached)                        s.flags |= WUPS_PWR2_FLAG_USB_C_ATTACH;
+
+    s.charge_state = (uint8_t)Chg_Data.chg_state;
+    s.reserved     = 0;
+
+    /* --- INPUT --- */
+    /* vbus_in: our own PA1 ADC (post ideal-diode OR of USB-C + barrel),
+     * reliable in every state (mains on/off, MP2762A dead). */
+    s.vbus_in_mV = DC_Inp_Voltage_mV;
+    /* HUSB238 negotiated input contract; 0 already means "no USB-C PD". */
+    s.pd_in_mV   = Husb_Data.voltage_mV;
+    s.pd_in_mA   = Husb_Data.current_mA;
+
+    /* --- OUTPUT --- */
+    s.vbus_out_mV   = Vbus_Out_Voltage_mV;                              /* PA0 ADC */
+    /* TPS55289 getters are 0.1 V / 0.1 A units → *100 = mV / mA. */
+    s.vout_set_mV   = (uint16_t)((int32_t)tps55289_get_voltage_set_v10() * 100);
+    s.vout_read_mV  = (uint16_t)((int32_t)Tps_Vread_v10 * 100);
+    s.iout_limit_mA = (uint16_t)((int32_t)Tps_Iread_a10 * 100);        /* limit, not load */
+    pd_out_contract(&s.pd_out_mV, &s.pd_out_mA);
+
+    /* --- BATTERY --- */
+    /* vbat: our own PA5 ADC, authoritative (MP2762A reads 0 on battery). */
+    s.vbat_mV = Vbat_Voltage_mV;
+    s.ichg_mA = (int16_t)Chg_Data.ichg_ma;   /* charge current; 0 on discharge */
+
+    /* --- SYSTEM --- */
+    s.vsys_mV     = (uint16_t)Chg_Data.vsys_mv;   /* real fields now (v1 aliased these) */
+    s.iin_mA      = (uint16_t)Chg_Data.iin_ma;
+    s.temp_lm_dC  = Board_Temp_c10;
+    s.temp_mp_dC  = Chg_Data.tjunc_c10;           /* MP2762A_TJ_NA (-32768) when unpowered */
+
+    /* Pack TPS55289 STATUS bits into the high byte of `faults`; MP2762A fault
+     * byte stays in the low byte. bit8=SCP bit9=OCP bit10=OVP. */
     {
-        int16_t lm = Board_Temp_c10;
-        int16_t tj = Chg_Data.tjunc_c10;
-        s.temp_dC = (tj == MP2762A_TJ_NA) ? lm : ((tj > lm) ? tj : lm);
+        uint16_t tps_flags = 0;
+        if (Tps_Status_Latched & STATUS_SCP_BIT) tps_flags |= (1u << 8);
+        if (Tps_Status_Latched & STATUS_OCP_BIT) tps_flags |= (1u << 9);
+        if (Tps_Status_Latched & STATUS_OVP_BIT) tps_flags |= (1u << 10);
+        s.faults = (uint16_t)(Chg_Data.fault | tps_flags);
+        /* Clear the latch only after packing into the frame about to ship. */
+        Tps_Status_Latched = 0;
     }
-    /* v3 is source-only — the upstream USB-C PD negotiation is handled
-     * entirely by HUSB238 (U150), CH32X never acts as a sink. There is
-     * no SINK contract to report. Repurpose `pd_contract_mV` as VSYS
-     * (mV) and `pd_contract_mA` as IIN (mA from MP2762A) — both are
-     * critical to diagnose TPS55289 UVLO trips that don't show up in
-     * the STATUS register. This aliasing is a known protocol-v1 hack
-     * (see common/protocol_desc.md §7); the real fix is protocol v2
-     * with dedicated diag fields. */
-    s.pd_contract_mV = (uint16_t)Chg_Data.vsys_mv;
-    s.pd_contract_mA = (uint16_t)Chg_Data.iin_ma;
-    /* Pack TPS55289 STATUS bits into the high byte of `faults` so the
-     * MP2762A fault byte (low byte) is preserved. The host can see what
-     * tripped the converter without bumping the protocol version:
-     *   bit  8 (TPS SCP)  ← STATUS bit 7
-     *   bit  9 (TPS OCP)  ← STATUS bit 6
-     *   bit 10 (TPS OVP)  ← STATUS bit 5
-     */
-    uint16_t tps_flags = 0;
-    if (Tps_Status_Latched & STATUS_SCP_BIT) tps_flags |= (1u << 8);
-    if (Tps_Status_Latched & STATUS_OCP_BIT) tps_flags |= (1u << 9);
-    if (Tps_Status_Latched & STATUS_OVP_BIT) tps_flags |= (1u << 10);
-    s.faults = (uint16_t)(Chg_Data.fault | tps_flags);
-    /* Clear the latch only after the bits have been packed into the
-     * frame about to ship — otherwise a trip between read and frame
-     * emission would be lost. */
-    Tps_Status_Latched = 0;
+
+    s.uptime_s = Uptime_Sec;
 
     wups_send_frame(dst, WUPS_CLASS_POWER, WUPS_OP_PWR_STATUS,
                     flags, seq, &s, sizeof(s));
@@ -1278,6 +1296,10 @@ int main(void)
             Vbat_ADC_Val = Get_ADC_Val(ADC_Channel_5);
             Vbat_Voltage_mV = (UINT16)((UINT32)Vbat_ADC_Val * 10322u / 4096u);
 
+            /* Output rail from PA0 ADC: same 27.4k/5.1k divider as PA1, so the
+             * same 21029/4096 scale. Independent of the TPS55289 readback. */
+            Vbus_Out_Voltage_mV = (UINT16)((UINT32)Get_ADC_Val(ADC_Channel_0) * 21029 / 4096);
+
             /* Edge detector first — it reads the same fault latch the
              * status send below clears after packing. */
             wups_power_event_tick();
@@ -1423,6 +1445,11 @@ void ADC_Function_Init(void)
 
     RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOA, ENABLE);
     RCC_APB2PeriphClockCmd(RCC_APB2Periph_ADC1, ENABLE);
+
+    //PA0: VBUS_OUT_ADC — output rail to the Pi, 27.4k/5.1k divider (same as PA1)
+    GPIO_InitStructure.GPIO_Pin = GPIO_Pin_0;
+    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AIN;
+    GPIO_Init(GPIOA, &GPIO_InitStructure);
 
     //PA1: DC_INP_ADC_SRC
     GPIO_InitStructure.GPIO_Pin = GPIO_Pin_1;

--- a/firmware-ch32x/User/tps55289.c
+++ b/firmware-ch32x/User/tps55289.c
@@ -92,8 +92,10 @@ UINT8 tps55289_set_current_limit(float amps)
     if (amps < 0.0f || amps > 6.35f)
         return -1;
 
-    //int reg_val = (int)roundf(amps * IOUT_LSB_PER_AMP); // 0..100
-    int reg_val = (int) (amps * IOUT_LSB_PER_AMP); // 0..100
+    /* Round, don't truncate. Float repr of e.g. 1.8 is 1.79999… so the old
+     * (int) cast gave 35 LSB (1.75 A) instead of 36 (1.80 A); same rounding-down
+     * bit every non-exact target. roundf lands on the nearest 0.05 A LSB. */
+    int reg_val = (int)roundf(amps * IOUT_LSB_PER_AMP); // 0..127
 
     if (reg_val > 0x7F)
         reg_val = 0x7F;
@@ -101,7 +103,7 @@ UINT8 tps55289_set_current_limit(float amps)
     reg_val |= 0x80;    // enable bit
 
     tps55289_write_byte(REG_IOUT_LIMIT, (UINT8)reg_val);
-    g_current_set_a10 = (int16_t)(amps * 10.0f);
+    g_current_set_a10 = (int16_t)roundf(amps * 10.0f);  /* round: 5.2f*10=51.99→52, not 51 */
     return 0;
 }
 // -----------------------------------------------------------------------------
@@ -140,7 +142,7 @@ UINT8 tps55289_set_voltage(float vout)
 
     tps55289_write_byte(REG_VOUT_FS, vout_fs_val);
 	write_word_lsb_first(REG_REF_LSB, (UINT16)reg);
-	g_voltage_set_v10 = (int16_t)(vout * 10.0f);
+	g_voltage_set_v10 = (int16_t)roundf(vout * 10.0f);  /* round for parity with current cache */
 	return 0;
 }
 // -----------------------------------------------------------------------------

--- a/firmware-rp2040/src/main.cpp
+++ b/firmware-rp2040/src/main.cpp
@@ -586,26 +586,16 @@ static void drawScreenOutput() {
   oled.setTextSize(1);
   oled.setTextColor(SSD1306_WHITE);
 
-  // row0: RP2040's own ADC measurement of the Pi rail.
+  // row0: output rail voltage (RP2040's own ADC).
   oled.setCursor(0, 0);
-  oled.print(F("Vo R "));
+  oled.print(F("V "));
   oled.print(vbus_out_mV / 1000);
   oled.print(F("."));
   oled.print((vbus_out_mV % 1000) / 100);
   oled.print(F("V"));
 
-  // row1: CH32X PA0 measurement (fallback to ui.vr*100 if v2 field is 0,
-  // e.g. legacy v1 frames where vbus_out_ch_mV was never populated).
-  int vout_ch = (ui.vbus_out_ch_mV > 0) ? ui.vbus_out_ch_mV : (ui.vr * 100);
+  // row1: output PD contract to the Pi, or "PD N/A" when the rail is off.
   oled.setCursor(0, 8);
-  oled.print(F("Vo C "));
-  oled.print(vout_ch / 1000);
-  oled.print(F("."));
-  oled.print((vout_ch % 1000) / 100);
-  oled.print(F("V"));
-
-  // row2: output PD contract to the Pi, or "PD N/A" when the rail is off.
-  oled.setCursor(0, 16);
   if (ui.pd_out_mV > 0) {
     int v = ui.pd_out_mV / 1000;
     oled.print(F("PD"));
@@ -620,8 +610,8 @@ static void drawScreenOutput() {
     oled.print(F("PD N/A"));
   }
 
-  // row3: TPS55289 current limit (mA -> whole.frac A).
-  oled.setCursor(0, 24);
+  // row2: TPS55289 current limit (mA -> whole.frac A).
+  oled.setCursor(0, 16);
   oled.print(F("Ilim "));
   oled.print(ui.iout_limit_mA / 1000);
   oled.print(F("."));
@@ -636,9 +626,9 @@ static void drawScreenBattery() {
   oled.setTextSize(1);
   oled.setTextColor(SSD1306_WHITE);
 
-  // row0: RP2040 ADC battery voltage + SOC. "R %d.%dV%2d%%"
+  // row0: battery voltage + SOC (RP2040's own ADC). "V %d.%dV%2d%%"
   oled.setCursor(0, 0);
-  oled.print(F("R "));
+  oled.print(F("V "));
   oled.print(ui.bv / 1000);
   oled.print(F("."));
   oled.print((ui.bv % 1000) / 100);
@@ -647,27 +637,16 @@ static void drawScreenBattery() {
   oled.print(ui.soc);
   oled.print(F("%"));
 
-  // row1: CH32X battery voltage + SOC. "C %d.%dV%2d%%"
-  oled.setCursor(0, 8);
-  oled.print(F("C "));
-  oled.print(ui.vbc / 1000);
-  oled.print(F("."));
-  oled.print((ui.vbc % 1000) / 100);
-  oled.print(F("V"));
-  if (ui.soc_ch < 10) oled.print(F(" "));
-  oled.print(ui.soc_ch);
-  oled.print(F("%"));
-
-  // row2: charge/discharge mode (mains-aware: cs=0 on mains is "not charging",
+  // row1: charge/discharge mode (mains-aware: cs=0 on mains is "not charging",
   // not discharge).
-  oled.setCursor(0, 16);
+  oled.setCursor(0, 8);
   oled.print(F("Mode:"));
   oled.print(batteryModeLabel(ui.pg, ui.cs));
 
-  // row3: charge current (mA -> whole.frac A; absolute value for sign-safe
+  // row2: charge current (mA -> whole.frac A; absolute value for sign-safe
   // single-digit fraction). "Ich %d.%dA"
   int ich = abs(ui.ci);
-  oled.setCursor(0, 24);
+  oled.setCursor(0, 16);
   oled.print(F("Ich "));
   oled.print(ich / 1000);
   oled.print(F("."));

--- a/firmware-rp2040/src/main.cpp
+++ b/firmware-rp2040/src/main.cpp
@@ -535,7 +535,7 @@ static void drawScreenInput() {
 
   // row0: "IN  %2d.%dV" — VIN whole.frac (e.g. "IN  12.3V")
   oled.setCursor(0, 0);
-  oled.print(F("IN  "));
+  oled.print(F("IN "));
   int vi_w = ui.vi / 1000;
   if (vi_w < 10) oled.print(F(" "));
   oled.print(vi_w);
@@ -547,7 +547,7 @@ static void drawScreenInput() {
   oled.setCursor(0, 8);
   if (ui.pd_in_mV > 0) {
     int v = ui.pd_in_mV / 1000;
-    oled.print(F("PD"));
+    oled.print(F("PD "));
     if (v < 10) oled.print(F(" "));
     oled.print(v);
     oled.print(F("V"));
@@ -598,7 +598,7 @@ static void drawScreenOutput() {
   oled.setCursor(0, 8);
   if (ui.pd_out_mV > 0) {
     int v = ui.pd_out_mV / 1000;
-    oled.print(F("PD"));
+    oled.print(F("PD "));
     if (v < 10) oled.print(F(" "));
     oled.print(v);
     oled.print(F("V"));
@@ -612,7 +612,7 @@ static void drawScreenOutput() {
 
   // row2: TPS55289 current limit (mA -> whole.frac A).
   oled.setCursor(0, 16);
-  oled.print(F("Ilim "));
+  oled.print(F("Ilim  "));
   oled.print(ui.iout_limit_mA / 1000);
   oled.print(F("."));
   oled.print((ui.iout_limit_mA % 1000) / 100);
@@ -632,7 +632,7 @@ static void drawScreenBattery() {
   oled.print(ui.bv / 1000);
   oled.print(F("."));
   oled.print((ui.bv % 1000) / 100);
-  oled.print(F("V"));
+  oled.print(F("V "));
   if (ui.soc < 10) oled.print(F(" "));
   oled.print(ui.soc);
   oled.print(F("%"));

--- a/firmware-rp2040/src/main.cpp
+++ b/firmware-rp2040/src/main.cpp
@@ -174,11 +174,15 @@ constexpr uint8_t BTN_RIGHT_PIN = 14;  // GPIO14 - right button (active LOW)
 constexpr unsigned long DEBOUNCE_MS = 50;
 
 // --- Screen navigation ---
-constexpr uint8_t SCREEN_COUNT = 7;
-constexpr uint8_t SCREEN_PD_DIAG = 4;       // PD/TPS diagnostic readout
-constexpr uint8_t SCREEN_POWER_PATH = 5;    // VIN / IIN / VSYS power-path readout
-constexpr uint8_t SCREEN_POWER_CTRL = 6;    // last screen — buttons act as power on/off
-constexpr unsigned long AUTO_RETURN_MS = 15000;  // Auto-return to home after 15s
+// Screen strip (power.status v2 debug screens). Home (0) is the dashboard;
+// 1..4 are the developer readouts split along the v2 struct sections.
+constexpr uint8_t SCREEN_HOME    = 0;
+constexpr uint8_t SCREEN_INPUT   = 1;   // VIN / input PD contract / source
+constexpr uint8_t SCREEN_OUTPUT  = 2;   // Vout RP2040 vs CH32X / output PD / Ilim
+constexpr uint8_t SCREEN_BATTERY = 3;   // Vbat RP2040 vs CH32X / mode / charge current
+constexpr uint8_t SCREEN_SYSTEM  = 4;   // uptime / temps / fault bitmap
+constexpr uint8_t SCREEN_COUNT   = 5;
+constexpr unsigned long AUTO_RETURN_MS = 20000;  // Auto-return to home after 20s
 
 // --- Bad charger alert state ---
 bool badChargerAlertPlayed = false;
@@ -199,11 +203,20 @@ unsigned long lastInteractionTime = 0;
 bool lastBtnLeftState = HIGH;
 bool lastBtnRightState = HIGH;
 
-// --- Cached CH32X power.status (binary v1) ---
-// CH32X emits a power.status frame every 1 s. wups_on_local_frame() copies
-// the payload here and projects fields into the `ui` snapshot below.
+// --- Cached CH32X power.status ---
+// CH32X emits a power.status frame every 1 s. wups_on_local_frame() projects
+// fields into the `ui` snapshot below. The v2 redesign is NOT a prefix-
+// compatible superset of v1, so we cache the RAW payload (version-agnostic)
+// for the republish / uplink paths — forwarding the decoded struct would
+// truncate the v2 tail. Last_Power_Status / Last_Pwr_V2 are kept as decoded
+// snapshots for convenience but MUST NOT gate forwarding.
 wups_power_status_v1_t Last_Power_Status = {};
+static wups_power_status_v2_t Last_Pwr_V2 = {};
 unsigned long Last_Power_Status_Ms = 0;
+
+// Raw last-accepted power.status payload (any version) for republish/uplink.
+static uint8_t  Last_Pwr_Raw[WUPS_MAX_PAYLOAD];
+static uint16_t Last_Pwr_Raw_Len = 0;
 
 // --- UPS view: snapshot for OLED rendering and alarm logic ----------------
 // Populated by wups_on_local_frame() from CH32X power.status (binary v1)
@@ -224,6 +237,17 @@ static struct {
     int vr, ir;     // VBUS_OUT V/A (0.1 V / 0.1 A units)
     // Held at last known from previous protocol; not yet in v1 power.status:
     int pd, pdo, role, snk_ok, snk_v, snk_i;
+    // From CH32X power.status v2 (raw mV / mA, 0 = N/A sentinel for PD fields):
+    int pd_in_mV, pd_in_mA;     // HUSB238 input contract (0 = no contract)
+    int pd_out_mV, pd_out_mA;   // output PD contract to the Pi (0 = rail off)
+    int vbus_out_ch_mV;         // CH32X PA0 VBUS_OUT measurement (mV)
+    int vsys_mV;                // MP2762A VSYS rail (mV)
+    int iin_mA;                 // MP2762A charger input current (mA)
+    int temp_lm_dC;             // LM75B board temp (deci-Celsius)
+    int temp_mp_dC;             // MP2762A junction temp (deci-Celsius, -32768 = N/A)
+    int usb_c_attach;           // 1 if HUSB238 reports a PD contract present
+    int soc_ch;                 // SOC from CH32X vbat (0..100, LUT)
+    int iout_limit_mA;          // TPS55289 current LIMIT (mA)
     // Computed locally on RP2040:
     int bv;         // battery voltage (mV, ADC + EMA)
     int soc;        // 0..100 from LUT + adaptive EMA
@@ -439,6 +463,8 @@ static void drawScreenIndicator(uint8_t screen) {
 }
 
 // Screen 0: Home dashboard
+static const __FlashStringHelper* batteryModeLabel(bool mains, int cs);
+
 static void drawScreenHome(int soc, bool noBattery, uint8_t animPhase) {
   // Battery icon (left side, 10x22 pixels)
   drawBatteryIcon(0, 0, soc, displayCs, noBattery, animPhase);
@@ -459,17 +485,7 @@ static void drawScreenHome(int soc, bool noBattery, uint8_t animPhase) {
   // Middle line: charge state + battery voltage
   oled.setTextSize(1);
   oled.setCursor(15, 16);
-  if (noBattery) {
-    oled.print(F("NoB"));
-  } else {
-    switch (displayCs) {
-      case 0: oled.print(F("DSC")); break;
-      case 1: oled.print(F("PRE")); break;
-      case 2: oled.print(F("CHG")); break;
-      case 3: oled.print(F("FUL")); break;
-      default: oled.print(F("---")); break;
-    }
-  }
+  oled.print(batteryModeLabel(ui.pg, displayCs));
   // Battery voltage (right of charge state)
   oled.setCursor(39, 16);
   oled.print(ui.bv / 1000);
@@ -497,239 +513,228 @@ static void drawScreenHome(int soc, bool noBattery, uint8_t animPhase) {
   oled.print(F("V"));
 }
 
-// Screen 1: Power (TPS55289 SET vs READ)
-static void drawScreenPower() {
+// Map (mains-present, charge-state) to a 3-char mode label. On battery (no
+// mains) the MP2762A is unpowered and reports cs=0 — that is a genuine
+// discharge. On mains, cs=0 means "not charging" (idle / pack full), which
+// must NOT be shown as discharge. Used by Home and the Battery screen.
+static const __FlashStringHelper* batteryModeLabel(bool mains, int cs) {
+  if (!mains) return F("DSC");           // no mains -> discharging
+  switch (cs) {
+    case 1:  return F("PRE");
+    case 2:  return F("CHG");
+    case 3:  return F("FUL");
+    default: return F("IDL");            // mains present, not charging
+  }
+}
+
+// Screen 1 (INPUT): VIN, input PD contract (HUSB238), derived power, source.
+// 64x32, 6x8 font => max 10 chars per line at y=0/8/16/24.
+static void drawScreenInput() {
   oled.setTextSize(1);
   oled.setTextColor(SSD1306_WHITE);
 
-  // Line 0: Header
+  // row0: "IN  %2d.%dV" — VIN whole.frac (e.g. "IN  12.3V")
   oled.setCursor(0, 0);
-  oled.print(F("PWR SET:"));
+  oled.print(F("IN  "));
+  int vi_w = ui.vi / 1000;
+  if (vi_w < 10) oled.print(F(" "));
+  oled.print(vi_w);
+  oled.print(F("."));
+  oled.print((ui.vi % 1000) / 100);
+  oled.print(F("V"));
 
-  // Line 1: Voltage SET, Current SET
+  // row1: input PD contract, or "PD N/A" when no contract negotiated.
   oled.setCursor(0, 8);
-  oled.print(ui.vs / 10);
-  oled.print(F("."));
-  oled.print(ui.vs % 10);
-  oled.print(F("V "));
-  oled.print(ui.is / 10);
-  oled.print(F("."));
-  oled.print(ui.is % 10);
-  oled.print(F("A"));
+  if (ui.pd_in_mV > 0) {
+    int v = ui.pd_in_mV / 1000;
+    oled.print(F("PD"));
+    if (v < 10) oled.print(F(" "));
+    oled.print(v);
+    oled.print(F("V"));
+    oled.print(ui.pd_in_mA / 1000);
+    oled.print(F("."));
+    oled.print((ui.pd_in_mA % 1000) / 100);
+    oled.print(F("A"));
+  } else {
+    oled.print(F("PD N/A"));
+  }
 
-  // Line 2: Header
+  // row2: contract power (V*A, integer watts), only when a contract exists.
   oled.setCursor(0, 16);
-  oled.print(F("PWR RD:"));
+  if (ui.pd_in_mV > 0) {
+    int w = (ui.pd_in_mV / 1000) * (ui.pd_in_mA / 1000);
+    oled.print(F("="));
+    oled.print(w);
+    oled.print(F("W"));
+  }
 
-  // Line 3: Voltage READ, Current READ
+  // row3: which source is feeding us.
   oled.setCursor(0, 24);
-  oled.print(ui.vr / 10);
-  oled.print(F("."));
-  oled.print(ui.vr % 10);
-  oled.print(F("V "));
-  oled.print(ui.ir / 10);
-  oled.print(F("."));
-  oled.print(ui.ir % 10);
-  oled.print(F("A"));
+  if (ui.usb_c_attach) {
+    oled.print(F("SRC:USB-C"));
+  } else if (ui.pg) {
+    oled.print(F("SRC:BARR"));
+  } else {
+    oled.print(F("SRC:OFF"));
+  }
 
-  drawScreenIndicator(1);
+  drawScreenIndicator(SCREEN_INPUT);
 }
 
-// Screen 2: Battery details
+// Screen 2 (OUTPUT): RP2040 vs CH32X VBUS_OUT, output PD contract, Ilimit.
+static void drawScreenOutput() {
+  oled.setTextSize(1);
+  oled.setTextColor(SSD1306_WHITE);
+
+  // row0: RP2040's own ADC measurement of the Pi rail.
+  oled.setCursor(0, 0);
+  oled.print(F("Vo R "));
+  oled.print(vbus_out_mV / 1000);
+  oled.print(F("."));
+  oled.print((vbus_out_mV % 1000) / 100);
+  oled.print(F("V"));
+
+  // row1: CH32X PA0 measurement (fallback to ui.vr*100 if v2 field is 0,
+  // e.g. legacy v1 frames where vbus_out_ch_mV was never populated).
+  int vout_ch = (ui.vbus_out_ch_mV > 0) ? ui.vbus_out_ch_mV : (ui.vr * 100);
+  oled.setCursor(0, 8);
+  oled.print(F("Vo C "));
+  oled.print(vout_ch / 1000);
+  oled.print(F("."));
+  oled.print((vout_ch % 1000) / 100);
+  oled.print(F("V"));
+
+  // row2: output PD contract to the Pi, or "PD N/A" when the rail is off.
+  oled.setCursor(0, 16);
+  if (ui.pd_out_mV > 0) {
+    int v = ui.pd_out_mV / 1000;
+    oled.print(F("PD"));
+    if (v < 10) oled.print(F(" "));
+    oled.print(v);
+    oled.print(F("V"));
+    oled.print(ui.pd_out_mA / 1000);
+    oled.print(F("."));
+    oled.print((ui.pd_out_mA % 1000) / 100);
+    oled.print(F("A"));
+  } else {
+    oled.print(F("PD N/A"));
+  }
+
+  // row3: TPS55289 current limit (mA -> whole.frac A).
+  oled.setCursor(0, 24);
+  oled.print(F("Ilim "));
+  oled.print(ui.iout_limit_mA / 1000);
+  oled.print(F("."));
+  oled.print((ui.iout_limit_mA % 1000) / 100);
+  oled.print(F("A"));
+
+  drawScreenIndicator(SCREEN_OUTPUT);
+}
+
+// Screen 3 (BATTERY): RP2040 vs CH32X Vbat/SOC, charge mode, charge current.
 static void drawScreenBattery() {
   oled.setTextSize(1);
   oled.setTextColor(SSD1306_WHITE);
 
-  // Line 0: Temperature
+  // row0: RP2040 ADC battery voltage + SOC. "R %d.%dV%2d%%"
   oled.setCursor(0, 0);
-  oled.print(F("T:"));
-  oled.print(ui.t / 10);
-  oled.print(F("."));
-  oled.print(abs(ui.t % 10));
-  oled.print(F("C"));
-
-  // Line 1: Battery voltage (from ADC)
-  oled.setCursor(0, 8);
-  oled.print(F("Bat:"));
+  oled.print(F("R "));
   oled.print(ui.bv / 1000);
   oled.print(F("."));
-  int frac = (ui.bv % 1000) / 10;
-  if (frac < 10) oled.print(F("0"));
-  oled.print(frac);
+  oled.print((ui.bv % 1000) / 100);
   oled.print(F("V"));
+  if (ui.soc < 10) oled.print(F(" "));
+  oled.print(ui.soc);
+  oled.print(F("%"));
 
-  // Line 2: Charger fault flags (hex)
-  oled.setCursor(0, 16);
-  oled.print(F("CF:0x"));
-  if (ui.cf < 16) oled.print(F("0"));
-  oled.print(ui.cf, HEX);
-
-  // Line 3: Charge current
-  oled.setCursor(0, 24);
-  oled.print(F("CI:"));
-  oled.print(ui.ci);
-  oled.print(F("mA"));
-
-  drawScreenIndicator(2);
-}
-
-// Screen 3: USB-PD info (output side to RPi)
-static void drawScreenPDInfo() {
-  oled.setTextSize(1);
-  oled.setTextColor(SSD1306_WHITE);
-
-  // Line 0: Header
-  oled.setCursor(0, 0);
-  oled.print(F("PD OUT>Pi"));
-
-  // Line 1: PD State
+  // row1: CH32X battery voltage + SOC. "C %d.%dV%2d%%"
   oled.setCursor(0, 8);
-  oled.print(F("State:"));
-  oled.print(ui.pd);
-
-  // Line 2: PDO Index
-  oled.setCursor(0, 16);
-  oled.print(F("PDO:"));
-  oled.print(ui.pdo);
-
-  // Line 3: Output voltage (measured from ADC3)
-  oled.setCursor(0, 24);
-  oled.print(F("Vo:"));
-  oled.print(vbus_out_mV / 1000);
+  oled.print(F("C "));
+  oled.print(ui.vbc / 1000);
   oled.print(F("."));
-  oled.print((vbus_out_mV % 1000) / 100);
+  oled.print((ui.vbc % 1000) / 100);
   oled.print(F("V"));
+  if (ui.soc_ch < 10) oled.print(F(" "));
+  oled.print(ui.soc_ch);
+  oled.print(F("%"));
 
-  drawScreenIndicator(3);
+  // row2: charge/discharge mode (mains-aware: cs=0 on mains is "not charging",
+  // not discharge).
+  oled.setCursor(0, 16);
+  oled.print(F("Mode:"));
+  oled.print(batteryModeLabel(ui.pg, ui.cs));
+
+  // row3: charge current (mA -> whole.frac A; absolute value for sign-safe
+  // single-digit fraction). "Ich %d.%dA"
+  int ich = abs(ui.ci);
+  oled.setCursor(0, 24);
+  oled.print(F("Ich "));
+  oled.print(ich / 1000);
+  oled.print(F("."));
+  oled.print((ich % 1000) / 100);
+  oled.print(F("A"));
+
+  drawScreenIndicator(SCREEN_BATTERY);
 }
 
-// Screen 4: PD/TPS diagnostic readout. ui.vr/ir come from CH32X reading the
-// TPS55289 REF/IOUT_LIMIT registers back, so they reflect what's currently
-// programmed on the converter — which CH32X overwrites in STA_TX_ACCEPT to
-// match the negotiated PDO:
-//   pre-PD:        5.1V / 3.0A (VBUS_set_5V default)
-//   PDO #1 5V5A:   5.1V / 5.0A
-//   PDO #2 9V3A:   9.0V / 3.0A
-//   PDO #3 12V:   12.0V / 2.25A
-//   PDO #4 15V:   15.0V / 1.8A
-// (ui.vs/is map to pd_contract_mV/mA — that's the SINK side of CH32X, i.e.
-// the upstream charger contract, not the USB-C output. Don't use here.)
-// Vo is RP2040's own ADC reading of VBUS_OUT, independent of the CH32X path.
-static void drawScreenPDDiag() {
+// Screen 4 (SYSTEM): RP2040 uptime, both temps, fault bitmap.
+static void drawScreenSystem() {
   oled.setTextSize(1);
   oled.setTextColor(SSD1306_WHITE);
 
+  // row0: compact RP2040 uptime. "UP %s"
+  //   < 100 min -> "%dm"; < 100 h -> "%dh%02dm" (or "%dh" once >= 10 h to
+  //   stay <= 10 chars); else "%dd".
+  unsigned long up_s = millis() / 1000UL;
+  unsigned long up_m = up_s / 60UL;
   oled.setCursor(0, 0);
-  oled.print(F("PD>Pi"));
-  /* TPS55289 STATUS bits packed into the high byte of `faults` by CH32X:
-   *   bit 8  = SCP (short-circuit protection)
-   *   bit 9  = OCP (overcurrent protection)
-   *   bit 10 = OVP (overvoltage protection)
-   * Show single-letter suffix when a trip is latched so it's obvious on
-   * the OLED what protection killed the rail. */
-  if (ui.cf & ((1 << 8) | (1 << 9) | (1 << 10))) {
-    oled.print(F(" !"));
-    if (ui.cf & (1 << 8))  oled.print(F("S"));
-    if (ui.cf & (1 << 9))  oled.print(F("O"));
-    if (ui.cf & (1 << 10)) oled.print(F("V"));
+  oled.print(F("UP "));
+  if (up_m < 100UL) {
+    oled.print(up_m);
+    oled.print(F("m"));
+  } else {
+    unsigned long up_h = up_m / 60UL;
+    if (up_h < 100UL) {
+      oled.print(up_h);
+      oled.print(F("h"));
+      if (up_h < 10UL) {
+        // "UP 9h59m" = 8 chars — room for minutes.
+        unsigned long rem_m = up_m % 60UL;
+        if (rem_m < 10UL) oled.print(F("0"));
+        oled.print(rem_m);
+        oled.print(F("m"));
+      }
+    } else {
+      oled.print(up_h / 24UL);
+      oled.print(F("d"));
+    }
   }
 
+  // row1: LM75B board temp (deci-C -> whole C). "Tlm %3dC"
   oled.setCursor(0, 8);
-  oled.print(F("S:"));
-  oled.print(ui.vr / 10);
-  oled.print(F("."));
-  oled.print(ui.vr % 10);
-  oled.print(F("V"));
+  oled.print(F("Tlm "));
+  oled.print(ui.temp_lm_dC / 10);
+  oled.print(F("C"));
 
+  // row2: MP2762A junction temp, "N/A" when unpowered (-32768 sentinel).
   oled.setCursor(0, 16);
-  oled.print(F("L:"));
-  oled.print(ui.ir / 10);
-  oled.print(F("."));
-  oled.print(ui.ir % 10);
-  oled.print(F("A"));
+  if (ui.temp_mp_dC == -32768) {
+    oled.print(F("Tmp  N/A"));
+  } else {
+    oled.print(F("Tmp "));
+    oled.print(ui.temp_mp_dC / 10);
+    oled.print(F("C"));
+  }
 
+  // row3: fault bitmap as 4 hex digits. "Flt:%04X"
   oled.setCursor(0, 24);
-  oled.print(F("Vo:"));
-  oled.print(vbus_out_mV / 1000);
-  oled.print(F("."));
-  int frac = (vbus_out_mV % 1000) / 10;
-  if (frac < 10) oled.print(F("0"));
-  oled.print(frac);
-  oled.print(F("V"));
+  oled.print(F("Flt:"));
+  unsigned int flt = (unsigned int)(ui.cf & 0xFFFF);
+  for (int sh = 12; sh >= 0; sh -= 4) {
+    oled.print((flt >> sh) & 0xF, HEX);
+  }
 
-  drawScreenIndicator(SCREEN_PD_DIAG);
-}
-
-// Screen 5: Power-path diagnostic. Diagnoses TPS55289 UVLO trips that
-// don't show up in STATUS register — typical signature when running with
-// no battery to cushion VSYS during a USB-C load step.
-//   Vi = VIN to MP2762A (DC IN, e.g. 12 V from barrel jack)
-//   Ii = IIN to MP2762A (current the chip is pulling from VIN)
-//   Vs = VSYS rail (the rail feeding TPS55289 VIN — if this dips below
-//        ~3 V under load, TPS resets and VBUS_OUT collapses)
-// CH32X diagnostic-aliases pd_contract_mV/mA to VSYS/IIN whenever there
-// is no upstream PD SINK contract (i.e. nearly always on the bench),
-// so ui.vs/is carry VSYS/IIN here.
-static void drawScreenPowerPath() {
-  oled.setTextSize(1);
-  oled.setTextColor(SSD1306_WHITE);
-
-  oled.setCursor(0, 0);
-  oled.print(F("Vi:"));
-  oled.print(ui.vi / 1000);
-  oled.print(F("."));
-  int vi_frac = (ui.vi % 1000) / 100;
-  oled.print(vi_frac);
-  oled.print(F("V"));
-
-  oled.setCursor(0, 8);
-  oled.print(F("Ii:"));
-  oled.print(ui.is / 10);
-  oled.print(F("."));
-  oled.print(ui.is % 10);
-  oled.print(F("A"));
-
-  oled.setCursor(0, 16);
-  oled.print(F("Vs:"));
-  /* ui.vs is in 0.1 V units (CH32X passes VSYS in mV through
-   * pd_contract_mV, then RP2040 divides by 100 → 0.1 V). */
-  oled.print(ui.vs / 10);
-  oled.print(F("."));
-  oled.print(ui.vs % 10);
-  oled.print(F("V"));
-
-  drawScreenIndicator(SCREEN_POWER_PATH);
-}
-
-// Screen 6: Power Control — LEFT disables VBUS_OUT, RIGHT re-enables it.
-static void drawScreenPowerCtrl() {
-  oled.setTextSize(1);
-  oled.setTextColor(SSD1306_WHITE);
-
-  // Line 0: header
-  oled.setCursor(0, 0);
-  oled.print(F("Power Ctrl"));
-
-  // Line 1: ON / OFF status — derived from RP2040's own VBUS_OUT ADC so
-  // we don't depend on the cached CH32X TPS55289 set values for the truth.
-  bool outputOn = (vbus_out_mV > 1000);
-  oled.setCursor(0, 8);
-  oled.print(F("OUT: "));
-  oled.print(outputOn ? F("ON") : F("OFF"));
-
-  // Line 2: button hint — LEFT turns off, RIGHT turns on
-  oled.setCursor(0, 16);
-  oled.print(F("<OFF  ON>"));
-
-  // Line 3: measured output voltage + screen indicator
-  oled.setCursor(0, 24);
-  oled.print(F("Vo:"));
-  oled.print(vbus_out_mV / 1000);
-  oled.print(F("."));
-  oled.print((vbus_out_mV % 1000) / 100);
-  oled.print(F("V"));
-
-  drawScreenIndicator(SCREEN_POWER_CTRL);
+  drawScreenIndicator(SCREEN_SYSTEM);
 }
 
 // --- Web3 Pi UPS binary wire protocol v1 — RP2040 hub-side handling ---
@@ -753,7 +758,7 @@ static void drawScreenPowerCtrl() {
 //
 // Defined here (in main.cpp) because the body needs access to RP2040
 // firmware globals (ui, lastFrameTime, etc.). Declared in wups_router.h.
-static void wupsPublishTelemetryStatus(uint8_t seq, const wups_power_status_v1_t& s);
+static void wupsPublishTelemetryStatus(uint8_t seq, const uint8_t* payload, uint16_t len);
 static void wupsPublishHostStatus(uint8_t seq, const wups_host_status_v1_t& s);
 static void wupsPublishCmdResponse(uint8_t cls, uint8_t op, uint8_t seq, uint8_t code);
 static void wupsPublishEventFrame(const WupsFrame& f);
@@ -793,71 +798,154 @@ void wups_on_local_frame(uint8_t inbound_port, const WupsFrame& f) {
   }
 
   // CH32X power.status — cache and project into the `ui` snapshot so the
-  // OLED / alarm code keeps working unchanged. PD detail and snk_* are not
-  // in v1 power.status; they stay at last known.
+  // OLED / alarm code keeps working unchanged. The wire format is version-
+  // dispatched on payload[0]: v2 (the current CH32X firmware) carries split
+  // INPUT/OUTPUT PD contracts + real VSYS/IIN; v1 is the legacy fallback.
+  // We forward/uplink the RAW payload (not a decoded struct) so the v2 tail
+  // is never truncated.
   if (f.cls == WUPS_CLASS_POWER && f.op == WUPS_OP_PWR_STATUS &&
-      f.src == WUPS_ADDR_CH32X &&
-      f.len >= sizeof(wups_power_status_v1_t)) {
-    wups_power_status_v1_t s;
-    memcpy(&s, f.payload, sizeof(s));
-    if (s.version != 1) return;
+      f.src == WUPS_ADDR_CH32X && f.len >= 1) {
+    const uint8_t pwrVersion = f.payload[0];
+    bool     decoded   = false;
+    bool     pgNow     = false;   // input "good" — set in whichever branch decodes
+    uint16_t faultsNow = 0;       // fault bitmap — set in whichever branch decodes
 
-    Last_Power_Status    = s;
+    if (pwrVersion == 2 && f.len >= sizeof(wups_power_status_v2_t)) {
+      // --- power.status v2 ---
+      wups_power_status_v2_t s2;
+      memcpy(&s2, f.payload, sizeof(s2));
+      Last_Pwr_V2 = s2;
+
+      // Temperature: prefer MP2762A junction temp, but it reads -32768 when
+      // the charger is unpowered — fall back to LM75B board temp then.
+      ui.t  = (s2.temp_mp_dC == -32768) ? s2.temp_lm_dC
+                                        : max((int)s2.temp_mp_dC, (int)s2.temp_lm_dC);
+      ui.cs = s2.charge_state;
+      ui.pg = (s2.vbus_in_mV > 5000) ? 1 : 0;
+      ui.vi = s2.vbus_in_mV;
+      ui.ci = s2.ichg_mA;
+      ui.cf = s2.faults;
+      ui.bp = (s2.flags & WUPS_PWR2_FLAG_BATT_PRESENT) ? 1 : 0;
+      ui.vb  = s2.vbat_mV;
+      ui.vbc = s2.vbat_mV;
+      ui.vr  = (int)(s2.vout_read_mV / 100);
+      ui.ir  = (int)(s2.iout_limit_mA / 100);
+      ui.vs  = (int)(s2.vout_set_mV  / 100);
+      ui.is  = (int)(s2.iout_limit_mA / 100);
+      // New v2 fields.
+      ui.pd_in_mV     = s2.pd_in_mV;
+      ui.pd_in_mA     = s2.pd_in_mA;
+      ui.pd_out_mV    = s2.pd_out_mV;
+      ui.pd_out_mA    = s2.pd_out_mA;
+      ui.vbus_out_ch_mV = s2.vbus_out_mV;
+      ui.vsys_mV      = s2.vsys_mV;
+      ui.iin_mA       = s2.iin_mA;
+      ui.temp_lm_dC   = s2.temp_lm_dC;
+      ui.temp_mp_dC   = s2.temp_mp_dC;
+      ui.usb_c_attach = (s2.flags & WUPS_PWR2_FLAG_USB_C_ATTACH) ? 1 : 0;
+      ui.iout_limit_mA = s2.iout_limit_mA;
+      ui.soc_ch       = voltageToSoc(s2.vbat_mV);
+
+      pgNow     = (s2.vbus_in_mV > 5000);
+      faultsNow = s2.faults;
+      decoded   = true;
+    } else if (pwrVersion == 1 && f.len >= sizeof(wups_power_status_v1_t)) {
+      // --- power.status v1 (legacy fallback, mapping unchanged) ---
+      wups_power_status_v1_t s;
+      memcpy(&s, f.payload, sizeof(s));
+      Last_Power_Status = s;
+
+      ui.t   = s.temp_dC;
+      ui.cs  = s.charge_state;
+      ui.pg  = (s.vbus_in_mV > 5000) ? 1 : 0;     // derived: input "good"
+      ui.vi  = s.vbus_in_mV;
+      ui.ci  = s.ibat_mA;
+      ui.cf  = s.faults;
+      ui.bp  = (s.vbat_mV > 100) ? 1 : 0;          // derived: battery present
+      ui.vb  = s.vbat_mV;
+      ui.vbc = s.vbat_mV;                          // single source in v1
+      // Set vs read separation lost in v1: report measured values for both.
+      ui.vs  = (int)(s.pd_contract_mV / 100);
+      ui.is  = (int)(s.pd_contract_mA / 100);
+      ui.vr  = (int)(s.vbus_out_mV / 100);
+      ui.ir  = (int)(s.ibus_out_mA / 100);
+      // PD detail (pd, pdo, role, snk_*) is not in v1 power.status — hold previous values.
+
+      pgNow     = (s.vbus_in_mV > 5000);
+      faultsNow = s.faults;
+      decoded   = true;
+    }
+
+    if (!decoded) return;  // unknown version or short frame — drop
+
+    // Cache the RAW payload (version-agnostic) for the on-demand republish
+    // and the throttled uplink — forwarding a decoded struct would truncate
+    // the v2 tail.
+    if (f.len <= sizeof(Last_Pwr_Raw)) {
+      memcpy(Last_Pwr_Raw, f.payload, f.len);
+      Last_Pwr_Raw_Len = f.len;
+    }
     Last_Power_Status_Ms = millis();
-
-    ui.t   = s.temp_dC;
-    ui.cs  = s.charge_state;
-    ui.pg  = (s.vbus_in_mV > 5000) ? 1 : 0;     // derived: input "good"
-    ui.vi  = s.vbus_in_mV;
-    ui.ci  = s.ibat_mA;
-    ui.cf  = s.faults;
-    ui.bp  = (s.vbat_mV > 100) ? 1 : 0;          // derived: battery present
-    ui.vb  = s.vbat_mV;
-    ui.vbc = s.vbat_mV;                          // single source in v1
-    // Set vs read separation lost in v1: report measured values for both.
-    ui.vs  = (int)(s.pd_contract_mV / 100);
-    ui.is  = (int)(s.pd_contract_mA / 100);
-    ui.vr  = (int)(s.vbus_out_mV / 100);
-    ui.ir  = (int)(s.ibus_out_mA / 100);
-    // PD detail (pd, pdo, role, snk_*) is not in v1 power.status — hold previous values.
-
     newFrameReceived = true;
     lastFrameTime    = millis();
 
     // Mirror parsed power.status to the debug stream (USB-CDC + Probe UART
     // via J350) so the firmware author can read CH32X telemetry remotely
-    // without unplugging the bench setup. One line per frame, fixed
-    // column order so it's easy to grep / diff between runs.
+    // without unplugging the bench setup. One line per frame, fixed column
+    // order so it's easy to grep / diff between runs. For v2, Vsys/Iin come
+    // from the real dedicated fields (not the v1 pd_contract aliasing).
     dbgOut.print(F("[t="));
     dbgOut.print(millis() / 1000);
-    dbgOut.print(F("s] cs="));
-    dbgOut.print(s.charge_state);
+    dbgOut.print(F("s] v="));
+    dbgOut.print(pwrVersion);
+    dbgOut.print(F(" cs="));
+    dbgOut.print(ui.cs);
     dbgOut.print(F(" pg="));
-    dbgOut.print((s.vbus_in_mV > 5000) ? 1 : 0);
+    dbgOut.print(pgNow ? 1 : 0);
     dbgOut.print(F(" Vin="));
-    dbgOut.print(s.vbus_in_mV);
-    dbgOut.print(F("mV Vsys="));
-    dbgOut.print(s.pd_contract_mV);   // diag-aliased (see CH32X main.c)
-    dbgOut.print(F("mV Iin="));
-    dbgOut.print(s.pd_contract_mA);   // diag-aliased
+    dbgOut.print(ui.vi);
+    if (pwrVersion == 2) {
+      dbgOut.print(F("mV Vsys="));
+      dbgOut.print(Last_Pwr_V2.vsys_mV);
+      dbgOut.print(F("mV Iin="));
+      dbgOut.print(Last_Pwr_V2.iin_mA);
+    } else {
+      dbgOut.print(F("mV Vsys="));
+      dbgOut.print(Last_Power_Status.pd_contract_mV);   // diag-aliased (v1)
+      dbgOut.print(F("mV Iin="));
+      dbgOut.print(Last_Power_Status.pd_contract_mA);   // diag-aliased (v1)
+    }
     dbgOut.print(F("mA Vbat="));
-    dbgOut.print(s.vbat_mV);
+    dbgOut.print(ui.vbc);
     dbgOut.print(F("mV Ichg="));
-    dbgOut.print(s.ibat_mA);
+    dbgOut.print(ui.ci);
     dbgOut.print(F("mA Vout="));
-    dbgOut.print(s.vbus_out_mV);
-    dbgOut.print(F("mV Iout="));
-    dbgOut.print(s.ibus_out_mA);
-    dbgOut.print(F("mA T="));
-    dbgOut.print(s.temp_dC);
+    dbgOut.print((pwrVersion == 2) ? ui.vbus_out_ch_mV : (ui.vr * 100));
+    dbgOut.print(F("mV T="));
+    dbgOut.print(ui.t);
     dbgOut.print(F("dC f=0x"));
-    dbgOut.println(s.faults, HEX);
+    dbgOut.println((unsigned int)faultsNow, HEX);
 
-    // Push-mode aggregate to RPi: forward the same frame on USB-CDC with
-    // SRC=CH32X preserved. RPi service decodes and treats it as authoritative.
+    // --- DIAG (temporary): ADC comparison — RP2040 own ADC (ui.bv, drives
+    // the OLED SOC) vs CH32X PA5 (ui.vbc). Lets us see on one line which
+    // source is closer to a bench multimeter. Remove once the SOC source is
+    // settled. 1 Hz (one per CH32X power.status frame). grep tag: [ADCcmp]
+    dbgOut.print(F("[ADCcmp] RP2040_bv="));
+    dbgOut.print(ui.bv);
+    dbgOut.print(F("mV soc="));
+    dbgOut.print(ui.soc);
+    dbgOut.print(F("% | CH32X_vbat="));
+    dbgOut.print(ui.vbc);
+    dbgOut.print(F("mV | delta(RP-CH)="));
+    dbgOut.print(ui.bv - ui.vbc);
+    dbgOut.println(F("mV"));
+
+    // Push-mode aggregate to RPi: forward the RAW payload on USB-CDC with
+    // SRC=CH32X preserved (so the v2 tail survives). RPi service decodes and
+    // treats it as authoritative.
     wups_send_with_src(WUPS_PORT_RPI, WUPS_ADDR_RPI, WUPS_ADDR_CH32X,
                        WUPS_CLASS_POWER, WUPS_OP_PWR_STATUS,
-                       WUPS_FLAG_EVENT, f.seq, &s, sizeof(s));
+                       WUPS_FLAG_EVENT, f.seq, f.payload, f.len);
 
     // Drive the cellular uplink via net.publish to the ESP32. ESP32 is a
     // dumb pipe to MQTT — it forwards `topic`+`payload` to the broker and
@@ -869,9 +957,7 @@ void wups_on_local_frame(uint8_t inbound_port, const WupsFrame& f) {
     // budget, with an immediate publish whenever the input-power state or
     // the charger fault bitmap changes (see notes at the static decls).
     {
-      const bool     pgNow     = (s.vbus_in_mV > 5000);
-      const uint16_t faultsNow = s.faults;
-      const uint32_t nowMs     = millis();
+      const uint32_t nowMs = millis();
       bool publishNow;
       if (!Telemetry_Uplink_Primed) {
         publishNow = true;                  // first frame: announce we're online
@@ -883,7 +969,7 @@ void wups_on_local_frame(uint8_t inbound_port, const WupsFrame& f) {
                          >= TELEMETRY_UPLINK_INTERVAL_MS;
       }
       if (publishNow) {
-        wupsPublishTelemetryStatus(f.seq, s);
+        wupsPublishTelemetryStatus(f.seq, f.payload, f.len);
         Last_Telemetry_Uplink_Ms = nowMs;
         Last_Uplink_Pg           = pgNow;
         Last_Uplink_Faults       = faultsNow;
@@ -976,8 +1062,10 @@ void wups_on_local_frame(uint8_t inbound_port, const WupsFrame& f) {
   // Iout / temperature granularity.
   if (f.cls == WUPS_CLASS_POWER && f.op == WUPS_OP_PWR_STATUS &&
       (f.flags & WUPS_FLAG_REQ)) {
-    if (Last_Power_Status_Ms != 0) {
-      wupsPublishTelemetryStatus(f.seq, Last_Power_Status);
+    if (Last_Power_Status_Ms != 0 && Last_Pwr_Raw_Len != 0) {
+      // Republish the RAW cached payload (any version) so the v2 tail is
+      // preserved end-to-end.
+      wupsPublishTelemetryStatus(f.seq, Last_Pwr_Raw, Last_Pwr_Raw_Len);
     }
     wupsPublishCmdResponse(f.cls, f.op, f.seq, /*code=*/0);
     return;
@@ -1028,10 +1116,10 @@ void wups_on_local_frame(uint8_t inbound_port, const WupsFrame& f) {
 
   // ADR-0012 — ui.set_screen forces a particular dashboard screen.
   // Used by the system menu's "Debug" entry: it puts the RP2040 on one
-  // of the developer screens (1=Power, 2=Battery, 3=PD, 4=Power Ctrl)
+  // of the developer screens (1=INPUT, 2=OUTPUT, 3=BATTERY, 4=SYSTEM)
   // and the user can navigate them with the normal LEFT/RIGHT shorts
-  // (which only run when currentScreen != 0). Auto-return to home (15s
-  // idle) brings the user back to the dashboard / menu activation
+  // (which now run on every screen, Home included). Auto-return to home
+  // (20s idle) brings the user back to the dashboard / menu activation
   // gesture window.
   if (f.cls == WUPS_CLASS_UI && f.op == WUPS_OP_UI_SET_SCREEN &&
       f.len >= sizeof(wups_ui_set_screen_v1_t)) {
@@ -1209,15 +1297,18 @@ static void wupsPublishCmdResponse(uint8_t cls, uint8_t op, uint8_t seq,
   wupsRequestPublish("cmd/response", /*qos=*/1, /*retain=*/0, frame, (uint16_t)n);
 }
 
-// Wrap a cached CH32X power.status into a WUPS frame (src=CH32X preserved
-// for the panel's audit trail) and ship it to the ESP32 as net.publish
-// onto the "telemetry" subtopic.
-static void wupsPublishTelemetryStatus(uint8_t seq, const wups_power_status_v1_t& s) {
-  uint8_t frame[WUPS_FRAMING_BYTES + sizeof(wups_power_status_v1_t)];
+// Wrap a CH32X power.status RAW payload (any version — v1 or v2) into a WUPS
+// frame (src=CH32X preserved for the panel's audit trail) and ship it to the
+// ESP32 as net.publish onto the "telemetry" subtopic. Taking raw bytes (not a
+// decoded struct) keeps the v2 tail intact end-to-end; the panel's wupsproto
+// decoder version-dispatches on payload[0] just like we do.
+static void wupsPublishTelemetryStatus(uint8_t seq, const uint8_t* payload, uint16_t len) {
+  if (payload == nullptr || len == 0 || len > WUPS_MAX_PAYLOAD) return;
+  uint8_t frame[WUPS_FRAMING_BYTES + WUPS_MAX_PAYLOAD];
   size_t n = wupsBuildFrame(frame, sizeof(frame),
                             WUPS_ADDR_BROADCAST, WUPS_ADDR_CH32X,
                             WUPS_CLASS_POWER, WUPS_OP_PWR_STATUS,
-                            WUPS_FLAG_EVENT, seq, &s, sizeof(s));
+                            WUPS_FLAG_EVENT, seq, payload, len);
   if (n == 0) return;
   wupsRequestPublish("telemetry", /*qos=*/0, /*retain=*/0, frame, (uint16_t)n);
 }
@@ -1433,16 +1524,30 @@ void loop() {
   // button=0xFF, action=long} broadcast which the ESP32 interprets as
   // "open system menu". Exit isn't a hold — once the menu is open the
   // user selects "Back" (short press, just like any other nav).
-  // Gesture is one-shot per hold episode; latch clears on LEFT release.
+  //
+  // Short LEFT presses now also navigate the screen strip from Home (see
+  // the button-handling block below), so the hold must be distinguished
+  // from a tap WITHOUT being cancelled the instant a tap nav fires. We
+  // latch on the hold itself: the episode is gated on currentScreen==0 at
+  // the START of the hold (s_home_at_start), then driven purely by the
+  // LEFT held-state — so a short LEFT that bumps currentScreen off Home
+  // mid-hold doesn't reset the timer. s_menu_fired one-shots per episode;
+  // both latches clear on LEFT release. s_left_consumed tells the nav
+  // block below to skip the LEFT-release tap (the press became a hold).
+  static bool s_left_consumed = false;   // shared with nav block below
   {
-    static uint32_t s_left_start_ms = 0;
-    static bool     s_menu_fired    = false;
+    static uint32_t s_left_start_ms  = 0;
+    static bool     s_menu_fired     = false;
+    static bool     s_home_at_start  = false;
     constexpr uint32_t MENU_ACTIVATION_HOLD_MS = 2000;
     bool left_down = digitalRead(BTN_LEFT_PIN) == LOW;
-    if (left_down && currentScreen == 0) {
+    if (left_down) {
       uint32_t now_ms = millis();
-      if (s_left_start_ms == 0) s_left_start_ms = now_ms;
-      if (!s_menu_fired &&
+      if (s_left_start_ms == 0) {
+        s_left_start_ms = now_ms;
+        s_home_at_start = (currentScreen == 0);  // only Home arms the gesture
+      }
+      if (s_home_at_start && !s_menu_fired &&
           (now_ms - s_left_start_ms) >= MENU_ACTIVATION_HOLD_MS) {
         wups_ui_button_event_v1_t e;
         e.version  = 1;
@@ -1453,7 +1558,8 @@ void loop() {
                   WUPS_CLASS_UI, WUPS_OP_UI_BUTTON_EVENT,
                   WUPS_FLAG_EVENT, &e, sizeof(e));
         tone(BUZZER_PIN, 1200, 80);
-        s_menu_fired = true;
+        s_menu_fired    = true;
+        s_left_consumed = true;   // this LEFT became a hold — no tap nav
         // Control hands over to trust_ui as soon as the ESP32 sends
         // back the first menu prompt — the trust_ui_active() branch
         // at the top of loop() takes over then. If no prompt arrives
@@ -1464,15 +1570,16 @@ void loop() {
       }
     } else {
       s_left_start_ms = 0;
-      s_menu_fired = false;
+      s_menu_fired    = false;
+      s_home_at_start = false;
     }
   }
 
   // ESP32 timeout for the activation gesture above. If trust_ui took over,
   // the ESP32 responded — clear the pending state silently. Otherwise jump
-  // directly to the debug screens (Power=1 is the first one in the strip
-  // 1→2→3→PD_DIAG→POWER_PATH→POWER_CTRL); a second short beep flags the
-  // fallback so the user can tell the menu didn't open.
+  // directly to the debug screens (INPUT=1 is the first one in the strip
+  // 1→2→3→4); a second short beep flags the fallback so the user can tell
+  // the menu didn't open.
   //
   // TEMPORARY (2026-06-09): debug-screen fallback disabled. With no ESP32
   // module the long-LEFT gesture used to drop into the RP2040-local debug
@@ -1517,41 +1624,41 @@ void loop() {
   // back, the router can grow a per-port "stray byte sink".
 
   // --- Button handling ---
-  // ADR-0012 — on the home screen (screen 0) short button presses are
-  // intentionally NO-OPs. The home screen is the dashboard; the only
-  // valid interaction here is hold-RIGHT-2s to open the system menu
-  // (handled above). Short presses are reserved for the menu itself
-  // (LEFT=cursor up, RIGHT=select) once it's active, and trust_ui owns
-  // the buttons while the menu / claim flow is up.
+  // Short LEFT/RIGHT presses cycle the screen strip on EVERY screen,
+  // including Home: RIGHT = next, LEFT = previous, both wrap around
+  // SCREEN_COUNT. This supersedes the old ADR-0012 home no-op — the owner
+  // wants the v2 debug screens reachable directly from Home.
   //
-  // On non-home screens (currently unreachable until "MENU > Debug"
-  // wiring lands) the original LEFT/RIGHT nav + SCREEN_POWER_CTRL
-  // power buttons still apply, so the code path is preserved.
+  // RIGHT has no hold meaning, so it navigates on the press edge (snappy).
+  // LEFT doubles as the system-menu hold gesture, so to keep both working
+  // cleanly on Home we navigate LEFT on its RELEASE edge and only when the
+  // press did NOT become a hold (s_left_consumed, set by the gesture block
+  // above). That way a quick LEFT tap goes back one screen while a 2 s LEFT
+  // hold opens the menu without first flicking the display to SYSTEM.
+  // trust_ui owns the buttons while the menu / claim flow is up, so this
+  // block is skipped entirely in that mode (early return at top of loop()).
   int8_t btnAction = checkButtons();
-  if (btnAction != 0 && currentScreen != 0) {
+  if (btnAction > 0) {
+    // RIGHT pressed - next screen (wrap)
     lastInteractionTime = millis();
-
-    if (currentScreen == SCREEN_POWER_CTRL) {
-      // Power Control screen: send a binary REQ to CH32X. No NEED_ACK in v1,
-      // so we don't wait for a response — confirmation comes via the next
-      // power.status push (vbus_out_mV transitioning).
-      uint8_t op  = (btnAction < 0) ? WUPS_OP_PWR_DISABLE : WUPS_OP_PWR_ENABLE;
-      uint8_t seq = wups_send(WUPS_PORT_CH32X, WUPS_ADDR_CH32X,
-                              WUPS_CLASS_POWER, op, WUPS_FLAG_REQ,
-                              nullptr, 0);
-      dbgOut.print(btnAction < 0 ? F("[btn] LEFT -> power.disable seq=")
-                                 : F("[btn] RIGHT -> power.enable seq="));
-      dbgOut.println(seq);
-    } else {
-      if (btnAction > 0) {
-        // RIGHT pressed - next screen (wrap)
-        currentScreen = (currentScreen + 1) % SCREEN_COUNT;
-      } else {
-        // LEFT pressed - previous screen (wrap)
-        currentScreen = (currentScreen + SCREEN_COUNT - 1) % SCREEN_COUNT;
-      }
-    }
+    currentScreen = (currentScreen + 1) % SCREEN_COUNT;
     tone(BUZZER_PIN, 1000, 20);
+  }
+
+  // LEFT release-edge nav: previous screen (wrap), unless this LEFT episode
+  // already fired the system-menu hold gesture.
+  {
+    static bool s_left_prev_down = false;
+    bool left_down = digitalRead(BTN_LEFT_PIN) == LOW;
+    if (s_left_prev_down && !left_down) {       // release edge
+      if (!s_left_consumed) {
+        lastInteractionTime = millis();
+        currentScreen = (currentScreen + SCREEN_COUNT - 1) % SCREEN_COUNT;
+        tone(BUZZER_PIN, 1000, 20);
+      }
+      s_left_consumed = false;   // re-arm for the next LEFT episode
+    }
+    s_left_prev_down = left_down;
   }
 
   // Auto-return to home screen after timeout
@@ -1604,35 +1711,17 @@ void loop() {
       previousPowerGood = (ui.pg == 1);
       lastLowBatteryBeep = millis();
       displayCs = ui.cs;
-      noBatteryDebounced = (lastFrameTime > 0) ? (ui.bp == 0)
-                         : (ui.bv > 10000 || ui.bv < 5000);
     } else {
       delay(50);
       return;
     }
   }
 
-  // Battery presence detection:
-  // Primary: use bp (battery present) from MP2762A charger IC (hardware UVLO threshold)
-  // Fallback: voltage-based detection when no UART data received yet
-  bool rawNoBattery;
-  if (lastFrameTime > 0) {
-    rawNoBattery = (ui.bp == 0);
-  } else {
-    rawNoBattery = (ui.bv > 10000) || (ui.bv < 5000);
-  }
-
-  // Debounce battery presence to prevent display flicker
-  if (rawNoBattery != noBatteryDebounced) {
-    noBatteryCounter++;
-    if (noBatteryCounter >= NO_BATTERY_DEBOUNCE) {
-      noBatteryDebounced = rawNoBattery;
-      noBatteryCounter = 0;
-    }
-  } else {
-    noBatteryCounter = 0;
-  }
-  bool noBattery = noBatteryDebounced;
+  // Battery-presence detection removed (owner decision 2026-06-21): the
+  // MP2762A presence signal is unreliable on this hardware — it falsely
+  // reports "no battery" when the pack is full and mains is present — and
+  // presence checking is not wanted. Always treat a battery as present.
+  bool noBattery = false;
 
   // Smooth displayed charge state to prevent CHG/FUL flicker at end-of-charge
   // (MP2762A toggles between CC and CV states when battery is nearly full)
@@ -1691,26 +1780,20 @@ void loop() {
 
     // Draw current screen based on navigation
     switch (currentScreen) {
-      case 0:
+      case SCREEN_HOME:
         drawScreenHome(soc, noBattery, animPhase);
         break;
-      case 1:
-        drawScreenPower();
+      case SCREEN_INPUT:
+        drawScreenInput();
         break;
-      case 2:
+      case SCREEN_OUTPUT:
+        drawScreenOutput();
+        break;
+      case SCREEN_BATTERY:
         drawScreenBattery();
         break;
-      case 3:
-        drawScreenPDInfo();
-        break;
-      case SCREEN_PD_DIAG:
-        drawScreenPDDiag();
-        break;
-      case SCREEN_POWER_PATH:
-        drawScreenPowerPath();
-        break;
-      case SCREEN_POWER_CTRL:
-        drawScreenPowerCtrl();
+      case SCREEN_SYSTEM:
+        drawScreenSystem();
         break;
     }
   }


### PR DESCRIPTION
## Summary

Brings `exp` up to date on `main` (4 commits, +706/−398 across 7 files). Three themes: a new **power.status v2** telemetry protocol with separate INPUT/OUTPUT PD contracts, a **reworked RP2040 OLED UI**, and **output PD current-limit tuning** on the CH32X so the rail reliably hits full rated power.

## Changes

### Telemetry — `power.status` v2 (`common/`, `firmware-ch32x`, `firmware-rp2040`)
- New `wups_power_status_v2_t` (version=2, 40 B): splits the **INPUT (HUSB238)** and **OUTPUT** PD contracts, carries real `vsys_mV` / `iin_mA` (no longer aliased onto `pd_contract_*`), separate LM75B / MP2762A temps, packed flags byte.
- Receivers **dispatch on the version byte** → v1 and v2 both parse (backward compatible).
- CH32X emits v2, samples PA0 (VBUS_OUT ADC), derives the output PD contract from `PD_Ctl.ReqPDO_Idx`.
- RP2040 forwards + MQTT-uplinks the **raw payload** so the v2 tail isn't truncated at the hub.
- `protocol_desc.md` updated, stale LEN example fixed.

### RP2040 OLED UI (`firmware-rp2040/src/main.cpp`)
- New **INPUT / OUTPUT / BATTERY / SYSTEM** screens (64×32), 20 s auto-return, home-screen short-press navigation.
- OUTPUT/BATTERY show a **single voltage** (RP2040 ADC, labelled "V") — the dual RP2040-vs-CH32X rows were only needed while diagnosing the now-resolved battery-sense issue.
- Removed battery-presence detection (unreliable on this HW); mains-aware charge/discharge mode label.

### Output PD current limits (`firmware-ch32x`)
- TPS55289 current limit set a few % above each negotiated PDO so the rail sources full rated power (~27 W) under test load without folding into constant-current at the profile boundary: **5A→5.2, 3A→3.1, 2.25A→2.3, 1.8A→1.9 A**.
- `roundf` instead of truncation in `set_current_limit` and the 0.1 A telemetry set-caches → values land exactly and stay stable across the 2 s watchdog re-apply (fixes 1.8 A→1.75 A and 5.2→5.1 A erosion).

### Docs
- `docs/QuickStart.md`: documents the four **output PD profiles** (5.1 V/5 A default, 9 V/3 A, 12 V/2.25 A, 15 V/1.8 A).

## Testing
- CH32X firmware builds clean (`riscv-none-embed-gcc`, no warnings).
- power.status v2 firmware + host path reviewed.

## Notes
- Wire protocol stays backward compatible (version-dispatch); no host-side breakage expected for v1 consumers.
- Panel / ESP32 v2 enrichment is a separate follow-up (batch 2), not in this PR.
